### PR TITLE
Moved file Close() outside of the scanner loop.

### DIFF
--- a/command/parse.go
+++ b/command/parse.go
@@ -273,8 +273,8 @@ func search() ([]Todo, error) {
 				}
 				todos = append(todos, todo)
 			}
-			fh.Close()
 		}
+		fh.Close()
 	}
 	return todos, nil
 }


### PR DESCRIPTION
Moved the call to Close() for the file outside of the loop for the scanner in the search() function.  Since the file was being closed on each iteration, the buffer for the scanner would reach 4096 bytes and not consider the rest of the file.

I ran into this when trying to parse a TODO comment in one of my larger source files.  Just to be sure, I tested against a file with a bunch of arbitrary characters up to 4096 bytes.  Any TODOs after 4096 were ignored. 